### PR TITLE
Add session timeout with lazy auto-archival

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,6 +238,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +263,7 @@ dependencies = [
  "base64",
  "chrono",
  "eventsource-stream",
+ "filetime",
  "futures",
  "hex",
  "hmac",
@@ -814,6 +826,7 @@ checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
  "bitflags",
  "libc",
+ "redox_syscall 0.7.0",
 ]
 
 [[package]]
@@ -1034,7 +1047,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1217,6 +1230,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,3 +68,4 @@ html2text = "0.14"
 
 [dev-dependencies]
 tempfile = "3"
+filetime = "0.2"

--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ allowed_jids = ["admin@localhost"]
 [memory]
 backend = "markdown"
 path = "./data/memory"
+
+[session]
+idle_timeout_mins = 240   # Auto-archive after 4 hours of inactivity (0 = disabled)
 ```
 
 Memory is stored as human-readable markdown files, workspace files for global agent configuration and per-JID directories for isolated user data. This makes agent memory inspectable, editable, and git-friendly. Admins can customize agent behavior by creating `instructions.md`, `identity.md`, and `personality.md` in the memory root directory.
@@ -313,6 +316,7 @@ Each user has a current conversation session (`history.jsonl`) and optionally ar
 - **`/new`** archives the current session to `sessions/{YYYYMMDD-HHMMSS}.jsonl` and clears the LLM context.
 - **`/forget`** erases the current history, user profile (`user.md`), and memory (`memory.md`) but preserves archived sessions.
 - **`/status`** shows the number of messages in the current session and how many sessions have been archived.
+- **Session timeout** — idle sessions are automatically archived when the next message arrives after a configurable inactivity period. This is lazy (no background timer) and works per-user and per-room.
 
 Memory layout:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,10 +34,23 @@ Implemented: the agent supports discrete sessions per user.
 - **Memory layout** — `{jid}/history.jsonl` (current session, JSONL format), `{jid}/sessions/*.jsonl` (archived), `{jid}/user.md` (user profile), `{jid}/memory.md` (long-term notes).
 - **`/status`** — Reports message count in current session and number of archived sessions.
 
+#### Session timeout ✓
+
+Implemented: idle sessions are automatically archived when the next message arrives.
+
+- **Lazy evaluation** — No background timer. When a message arrives, the runtime checks the session file's modification time. If idle longer than `idle_timeout_mins`, the session is archived (same as `/new`) before processing the new message.
+- **Configurable** — `[session]` TOML section with `idle_timeout_mins` (default: 0 = disabled). Per-user and per-room (MUC sessions have their own timeout check).
+- **All handlers** — Freshness check runs in `handle_message`, `handle_muc_message`, `handle_reaction`, and `handle_message_with_attachments`.
+- **`/status`** — Shows session timeout configuration.
+
+```toml
+[session]
+idle_timeout_mins = 240   # Archive after 4 hours of inactivity (0 = disabled)
+```
+
 #### Future enhancements (not yet implemented)
 
 - **XMPP thread ID mapping** — When the XMPP client sends a `<thread>` element (XEP-0201), the agent maps it to a session. Different thread IDs = different sessions. Messages without a thread ID use the "default" session.
-- **Session timeout** — If no message is received for a configurable duration (e.g. 4 hours), the next message implicitly starts a new session. The timeout is per-user.
 - **Session context carry-over** — When a new session starts, the agent can optionally summarize the previous session into `context.md`, giving continuity without sending the full old history to the LLM.
 
 ### Presence subscription for allowed JIDs ✓

--- a/docs/XEPS.md
+++ b/docs/XEPS.md
@@ -8,12 +8,16 @@ Fluux Agent implements the following XMPP standards:
 
 Core XMPP protocol — XML streams, stanza routing, error handling.
 
-**Implementation:** Stream establishment, stanza parsing (quick-xml event-based `StanzaParser`), error condition handling (§4.9.3).
+**Implementation:** Stream establishment, stanza parsing (quick-xml event-based `StanzaParser`), error condition handling (§4.9.3), whitespace keepalive (§4.6.1).
+
+**Whitespace keepalive (§4.6.1):** The agent sends periodic whitespace pings (single space byte) to detect dead TCP connections — e.g., after machine sleep/wake. A configurable read timeout triggers a connection probe; if the write fails, the agent declares the connection lost and the reconnection loop takes over. This is non-destructive: a timeout alone does not disconnect — only a failed write does.
 
 **References:**
 - `src/xmpp/stanzas.rs:724` — stream error conditions (25 RFC 6120 conditions)
 - `src/xmpp/stanzas.rs:446` — `StanzaParser` (event-based XML stream parser)
-- `src/xmpp/component.rs` — stream management
+- `src/xmpp/component.rs` — stream management, keepalive ping handling, read timeout
+- `src/agent/runtime.rs:70` — ping interval timer and read timeout probe logic
+- `src/config.rs` — `KeepaliveConfig` (enabled, ping_interval_secs, read_timeout_secs)
 
 ---
 
@@ -215,7 +219,7 @@ See `docs/DEVELOPING.md` for rationale.
 ## Version History
 
 - **v0.1** — XEP-0114 (component mode), XEP-0085 (chat states), XEP-0045 (MUC), XEP-0066 (OOB file attachments)
-- **v0.2** — XEP-0444 inbound reactions, message ID embedding, C2S client mode (RFC 4616 PLAIN, RFC 5802 SCRAM-SHA-1, STARTTLS), JSONL session format
+- **v0.2** — XEP-0444 inbound reactions, message ID embedding, C2S client mode (RFC 4616 PLAIN, RFC 5802 SCRAM-SHA-1, STARTTLS), JSONL session format, RFC 6120 §4.6.1 whitespace keepalive
 
 ---
 


### PR DESCRIPTION
## Summary

- Add configurable idle session timeout (`[session] idle_timeout_mins`) that auto-archives stale sessions on next inbound message (lazy evaluation, no background timer)
- Freshness check integrated in all 4 message handlers (1:1 chat, MUC, reactions, attachments)
- `/status` reports session timeout configuration
- Update XEPS.md with keepalive documentation improvements
- Update README and ROADMAP to reflect the new feature